### PR TITLE
Update PreProcessor to parse definitions of functions' typed default args correctly

### DIFF
--- a/pycg/processing/base.py
+++ b/pycg/processing/base.py
@@ -202,7 +202,9 @@ class ProcessingBase(ast.NodeVisitor):
             do_assign(decoded, target)
 
     def decode_node(self, node):
-        if isinstance(node, ast.Name):
+        if isinstance(node, ast.Constant):
+             return [node.value]
+        elif isinstance(node, ast.Name):
             return [self.scope_manager.get_def(self.current_ns, node.id)]
         elif isinstance(node, ast.Call):
             decoded = self.decode_node(node.func)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -50,20 +50,21 @@ class PreProcessor(ProcessingBase):
 
     def _get_fun_defaults(self, node):
         defaults = {}
-        start = len(node.args.args) - len(node.args.defaults)
-        for cnt, d in enumerate(node.args.defaults, start=start):
-            if not d:
-                continue
 
-            self.visit(d)
-            defaults[node.args.args[cnt].arg] = self.decode_node(d)
+        args = node.args.args
+        pos_defaults = node.args.defaults
+        if pos_defaults:
+            for arg, default in zip(reversed(args), reversed(pos_defaults)):
+                if default:
+                    self.visit(default)
+                    defaults[arg.arg] = self.decode_node(default)
 
-        start = len(node.args.kwonlyargs) - len(node.args.kw_defaults)
-        for cnt, d in enumerate(node.args.kw_defaults, start=start):
-            if not d:
-                continue
-            self.visit(d)
-            defaults[node.args.kwonlyargs[cnt].arg] = self.decode_node(d)
+        kwonlyargs = node.args.kwonlyargs
+        kw_defaults = node.args.kw_defaults
+        for arg, default in zip(kwonlyargs, kw_defaults):
+            if default:
+                self.visit(default)
+                defaults[arg.arg] = self.decode_node(default)
 
         return defaults
 

--- a/pycg/tests/preprocessor_test.py
+++ b/pycg/tests/preprocessor_test.py
@@ -1,0 +1,76 @@
+import ast
+from unittest import TestCase
+from pycg.processing.preprocessor import PreProcessor
+
+class PreProcessorTest(TestCase):
+    def setUp(self):
+        self.preprocessor = PreProcessor(
+            filename="pycg/tests/preprocessor_test.py",
+            modname="test",
+            modules_analyzed=set(),
+            import_manager=None,
+            scope_manager=None,
+            def_manager=None,
+            class_manager=None,
+            module_manager=None
+        )
+
+    def test_get_fun_defaults_positional(self):
+        pos_defaults_function_def = """
+        def func(a, b=1, c="test"):
+            pass
+        """.lstrip()
+        node = ast.parse(pos_defaults_function_def).body[0]
+
+        defaults = self.preprocessor._get_fun_defaults(node)
+
+        self.assertEqual(defaults["b"], [1])
+        self.assertEqual(defaults["c"], ["test"])
+
+    def test_get_fun_defaults_typed_positional(self):
+        typed_defaults_function_def = """
+        def func(a, b: str | int = 1):
+            pass
+        """.lstrip()
+        node = ast.parse(typed_defaults_function_def).body[0]
+
+        defaults = self.preprocessor._get_fun_defaults(node)
+
+        self.assertEqual(defaults["b"], [1])
+
+    def test_get_fun_defaults_keyword(self):
+        kwonly_function_def = """
+        def func(kw1=True, kw2=42):
+            pass
+        """.lstrip()
+        node = ast.parse(kwonly_function_def).body[0]
+
+        defaults = self.preprocessor._get_fun_defaults(node)
+
+        self.assertEqual(defaults["kw1"], [True])
+        self.assertEqual(defaults["kw2"], [42])
+
+    def test_get_fun_defaults_positional_and_keyword(self):
+        pos_and_kw_arg_function_def = """
+        def func(a, b=1, *, kw1="test", kw2=False, kw3: str | None = None):
+            pass
+        """.lstrip()
+        node = ast.parse(pos_and_kw_arg_function_def).body[0]
+
+        defaults = self.preprocessor._get_fun_defaults(node)
+
+        self.assertEqual(defaults["b"], [1])
+        self.assertEqual(defaults["kw1"], ["test"])
+        self.assertEqual(defaults["kw2"], [False])
+        self.assertEqual(defaults["kw3"], [None])
+
+    def test_get_fun_defaults_none(self):
+        no_defaults_function_def = """
+        def func(a, b):
+            pass
+        """.lstrip()
+        node = ast.parse(no_defaults_function_def).body[0]
+
+        defaults = self.preprocessor._get_fun_defaults(node)
+
+        self.assertEqual(defaults, {})


### PR DESCRIPTION
## Why?

`PreProcessor#_get_fun_defaults` throws `IndexError: list index out of range` when processing this method definition:

```python
def bar(
    self,
    x: X | None = None,
    y: Y | None = None,
    color: Color | None = None,
     /,
    **kwargs: Unpack[EncodeKwds],
) -> alt.Chart:
```

When the argument types and default values are removed, however, the function definition is processed with no problem:

```python
def bar(
    self,
    x,
    y,
    color,
     /,
    **kwargs,
) -> alt.Chart:
```

This is because `_get_fun_defaults` does not handle type and default value information correctly.

## How?

This PR updates `PreProcessor#_get_fun_defaults` to handle function argument types and default values correctly. It also updates `ProcessingBase#decode_node` to ensure nodes of type `ast.Constant`, i.e. boolean and `None`, are handled correctly.

pycg/tests/preprocessor_test.py introduces tests exercising the methods that were changed.